### PR TITLE
feat: add omniAutoAnswerController LWC for selective Queue call auto-answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ You can check the Partner Telephony features  in your Partner Telephony Enabled 
 |simulatorPage	|Visualforce Page	|JS script refrenced in Simulator VF Page
 |slds_stylesheet	|Static Resource	|css for Simulator VF Page
 |symbols	|Static Resource	|image icons
+|omniAutoAnswerController	|Lightning Web Component Bundle	|Voice Extension component that auto-accepts inbound Queue calls while leaving DID / direct-extension calls for the agent to accept manually
 
 **Setup Instructions**
 
@@ -267,5 +268,41 @@ You can check the Partner Telephony features  in your Partner Telephony Enabled 
 
 * Package also includes LMS channel and Aura/lwc Record Home components and bridge components which you can add to  Voice Call RH and play with LMS. 
 * Note VF page connector is using AuraBridgeComponent and localhost connector is using lwcBridge component which are part of package.
+
+## Selective Auto-Answer for Queue Calls (omniAutoAnswerController)
+
+The `omniAutoAnswerController` LWC automatically accepts inbound **Queue** calls while leaving **DID / direct-extension** calls for the agent to accept manually. It uses the Voice Toolkit API's `callstarted` event and `acceptCall()` method — no Apex or additional permissions required.
+
+### How it works
+
+1. On `callstarted`, the component reads `callAttributes` from the event payload.
+2. If the attributes indicate a Queue-routed call (key varies by adapter — see below), it calls `acceptCall()` immediately.
+3. If no queue indicator is found, the component does nothing and the agent sees the normal Accept button.
+
+### Setup
+
+1. Deploy `omniAutoAnswerController` and `Omni_Auto_Answer_Voice_Extension` to your org.
+2. In Setup → **Contact Centers**, open your contact center → **SCV Settings**:
+   - Set **Voice Extension Flexipage** to `Omni Auto Answer Voice Extension`.
+   - Set **Always Show Voice Extension** to `true`.
+3. In your Omni-Channel presence configuration, ensure **Automatically accept work requests** is **unchecked**. The built-in Salesforce auto-accept overrides this component — it must be off for selective auto-answer to work.
+
+### Verifying the correct callAttributes key
+
+Partner telephony adapters surface routing context under different key names. The component checks three common ones:
+
+| Key | Expected value |
+|-----|---------------|
+| `routingType` | `"Queue"` |
+| `callRoutingType` | `"Queue"` |
+| `queueCall` | `true` |
+
+If auto-accept is not firing, open browser DevTools on the agent console and uncomment the debug line in `handleCallStarted` to log the raw payload:
+
+```javascript
+console.log('[OmniAutoAnswer] callAttributes:', JSON.stringify(detail));
+```
+
+This reveals the exact key your adapter uses so you can lock it in.
 
 

--- a/force-app/main/default/flexipages/Omni_Auto_Answer_Voice_Extension.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Omni_Auto_Answer_Voice_Extension.flexipage-meta.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentName>omniAutoAnswerController</componentName>
+                <identifier>REPLACE_WITH_NAMESPACE_NAME_omniAutoAnswerController</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>main</name>
+        <type>Region</type>
+    </flexiPageRegions>
+    <masterLabel>Omni Auto Answer Voice Extension</masterLabel>
+    <template>
+        <name>opencti:defaultVoiceExtensionTemplate</name>
+    </template>
+    <type>VoiceExtension</type>
+</FlexiPage>

--- a/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.html
+++ b/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.html
@@ -1,0 +1,15 @@
+<!--
+    Copyright (c) 2021, salesforce.com, inc.
+    All rights reserved.
+    SPDX-License-Identifier: BSD-3-Clause
+    For full license text, see the LICENSE file in the repo root or
+    https://opensource.org/licenses/BSD-3-Clause
+-->
+<template>
+    <!--
+        No visible UI — this component acts as a background controller only.
+        The toolkit API element below gives access to telephony events and
+        the acceptCall() method; it renders as an empty DOM node.
+    -->
+    <lightning-service-cloud-voice-toolkit-api></lightning-service-cloud-voice-toolkit-api>
+</template>

--- a/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.js
+++ b/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { LightningElement } from 'lwc';
+
+/**
+ * Automatically accepts inbound Queue calls while leaving DID / direct-extension
+ * calls for the agent to accept manually.
+ *
+ * Deploy this component as a Voice Extension on your Contact Center (Setup →
+ * Contact Centers → <your center> → SCV Settings → Voice Extension Flexipage).
+ * Leave "Automatically accept work requests" unchecked in Omni-Channel settings
+ * so that this component — not Salesforce — controls accept behavior.
+ *
+ * Partner telephony adapters surface routing context in callAttributes.
+ * The key name varies by adapter; the three most common are checked below.
+ * If none match, enable the debug block and inspect the console output to find
+ * the exact key your connector uses.
+ */
+export default class OmniAutoAnswerController extends LightningElement {
+    _hasRendered = false;
+    _accepting = false; // guard against duplicate callstarted events per call
+
+    constructor() {
+        super();
+        // Store bound references so the same function can be passed to removeEventListener
+        this._onCallStarted = this.handleCallStarted.bind(this);
+        this._onCallEnded = this.handleCallEnded.bind(this);
+    }
+
+    renderedCallback() {
+        if (this._hasRendered) return;
+        this._hasRendered = true;
+
+        const toolkit = this.template.querySelector(
+            'lightning-service-cloud-voice-toolkit-api'
+        );
+        if (!toolkit) return;
+
+        this._toolkit = toolkit;
+        toolkit.addEventListener('callstarted', this._onCallStarted);
+        toolkit.addEventListener('callended', this._onCallEnded);
+    }
+
+    disconnectedCallback() {
+        if (this._toolkit) {
+            this._toolkit.removeEventListener('callstarted', this._onCallStarted);
+            this._toolkit.removeEventListener('callended', this._onCallEnded);
+        }
+    }
+
+    handleCallStarted(event) {
+        if (this._accepting) return; // prevent duplicate acceptCall on repeated events
+
+        const detail = event.detail || {};
+        const attrs = detail.callAttributes || {};
+
+        /*
+         * Uncomment to log the raw callAttributes payload and identify which
+         * key your telephony adapter uses if auto-accept is not firing:
+         *
+         * console.log('[OmniAutoAnswer] callAttributes:', JSON.stringify(detail));
+         */
+
+        // Key names observed across common partner telephony adapters
+        const isQueueCall =
+            attrs.routingType === 'Queue' ||
+            attrs.callRoutingType === 'Queue' ||
+            attrs.queueCall === true;
+
+        if (!isQueueCall) {
+            return; // DID / direct-extension call — leave manual Accept for the agent
+        }
+
+        this._accepting = true;
+        console.log('[OmniAutoAnswer] Queue call detected, auto-accepting.');
+
+        this._toolkit
+            .acceptCall()
+            .then(() => console.log('[OmniAutoAnswer] Call accepted successfully.'))
+            .catch((err) => {
+                console.error('[OmniAutoAnswer] acceptCall failed:', err);
+                this._accepting = false; // reset so a retry is possible
+            });
+    }
+
+    handleCallEnded() {
+        this._accepting = false; // reset for the next call
+    }
+}

--- a/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.js-meta.xml
+++ b/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>Omni Auto Answer Controller</masterLabel>
+    <targets>
+        <target>lightning__VoiceExtension</target>
+    </targets>
+    <capabilities>
+        <capability>lightning__ServiceCloudVoiceToolkitApi</capability>
+    </capabilities>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary

- Adds `omniAutoAnswerController` LWC — a background Voice Extension component that listens to the `callstarted` event and calls `acceptCall()` only for Queue-routed calls, leaving DID / direct-extension calls for the agent to accept manually
- Adds `Omni_Auto_Answer_Voice_Extension` FlexiPage — ready to assign in Contact Center SCV Settings
- Adds README documentation covering setup, Omni-Channel configuration, and how to identify the correct `callAttributes` key for any partner telephony adapter

## How it works

The component uses `lightning-service-cloud-voice-toolkit-api` to subscribe to `callstarted`. On each event it reads `callAttributes` from the payload and checks three key names observed across common partner telephony adapters (`routingType`, `callRoutingType`, `queueCall`). If a Queue indicator is found it calls `acceptCall()`; otherwise it does nothing and the agent sees the normal Accept button.

Requires **Automatically accept work requests** to be **unchecked** in Omni-Channel settings — the built-in Salesforce auto-accept would bypass this component entirely if enabled.

## Test plan

- [ ] Deploy component and FlexiPage to a Partner Telephony-enabled org
- [ ] Assign `Omni Auto Answer Voice Extension` FlexiPage in Contact Center SCV Settings
- [ ] Confirm "Automatically accept work requests" is unchecked
- [ ] Place a Queue-routed inbound call — call should auto-accept; DevTools should show `[OmniAutoAnswer] Queue call detected` and `[OmniAutoAnswer] Call accepted successfully.`
- [ ] Place a DID / direct-extension inbound call — agent should see the Accept button and call should wait for manual accept; no `[OmniAutoAnswer]` logs