### PR TITLE
feat: add omniAutoAnswerController LWC for selective Queue call auto-answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ You can check the Partner Telephony features  in your Partner Telephony Enabled 
 |simulatorPage	|Visualforce Page	|JS script refrenced in Simulator VF Page
 |slds_stylesheet	|Static Resource	|css for Simulator VF Page
 |symbols	|Static Resource	|image icons
+|omniAutoAnswerController	|Lightning Web Component Bundle	|Voice Extension component that auto-accepts inbound Queue calls while leaving DID / direct-extension calls for the agent to accept manually
+|Omni_Auto_Answer_Voice_Extension	|FlexiPage	|VoiceExtension FlexiPage that wires omniAutoAnswerController to the Contact Center — assign this under SCV Settings → Voice Extension Flexipage
 
 **Setup Instructions**
 
@@ -267,5 +269,77 @@ You can check the Partner Telephony features  in your Partner Telephony Enabled 
 
 * Package also includes LMS channel and Aura/lwc Record Home components and bridge components which you can add to  Voice Call RH and play with LMS. 
 * Note VF page connector is using AuraBridgeComponent and localhost connector is using lwcBridge component which are part of package.
+
+## Selective Auto-Answer for Queue Calls (omniAutoAnswerController)
+
+### The Problem
+
+Salesforce's native **Automatically accept work requests** setting is all-or-nothing. Enabling it auto-accepts every call type, removing agent control over direct calls. Disabling it forces agents to manually click Accept on every call — adding friction on high-volume queue work. There is no out-of-the-box way to auto-accept one type and not the other.
+
+### What It Does
+
+`omniAutoAnswerController` is a background Voice Extension LWC that brings **intelligent, selective call auto-answering** to the agent console — without any Apex code, custom permissions, or third-party dependencies.
+
+- **Queue call?** → Auto-accepts immediately. The agent is connected without lifting a finger.
+- **DID / direct-extension call?** → Does nothing. The agent sees the standard Accept button and controls when to pick up.
+
+This mirrors how a physical ACD desk phone works: queue calls ring through automatically, direct calls wait for the agent to answer.
+
+### Key Capabilities
+
+| Capability | Detail |
+|---|---|
+| Selective auto-answer | Accepts Queue calls only; leaves DID / direct calls manual |
+| Adapter-agnostic | Checks all three common `callAttributes` key names used across partner telephony adapters |
+| Zero UI footprint | Runs entirely in the background; no visible panel or buttons rendered |
+| Memory-safe | Removes event listeners on component disconnect via `disconnectedCallback` |
+| Duplicate-proof | `_accepting` flag prevents repeated `acceptCall()` if the adapter fires `callstarted` more than once; resets on `callended` |
+| Debug-ready | Built-in commented hook to log raw `callAttributes` for adapter-specific key discovery |
+
+### Setup
+
+1. Deploy `omniAutoAnswerController` and `Omni_Auto_Answer_Voice_Extension` to your org.
+2. In Setup → **Contact Centers**, open your contact center → **SCV Settings**:
+   - Set **Voice Extension Flexipage** to `Omni Auto Answer Voice Extension`.
+   - Set **Always Show Voice Extension** to `true`.
+3. In your Omni-Channel presence configuration, ensure **Automatically accept work requests** is **unchecked**. The built-in Salesforce auto-accept overrides this component if enabled — it must be off for selective auto-answer to work.
+
+### How It Works
+
+1. On `callstarted`, the component reads `callAttributes` from the Voice Toolkit API event payload.
+2. If the attributes indicate a Queue-routed call, it calls `acceptCall()` immediately.
+3. If no queue indicator is found, the component does nothing and the agent sees the normal Accept button.
+4. On `callended`, internal state resets cleanly for the next call.
+
+### Verifying the Correct callAttributes Key
+
+Partner telephony adapters surface routing context under different key names. The component checks three common ones:
+
+| Key | Expected value |
+|-----|---------------|
+| `routingType` | `"Queue"` |
+| `callRoutingType` | `"Queue"` |
+| `queueCall` | `true` |
+
+If auto-accept is not firing, open browser DevTools on the agent console and uncomment the debug line in `handleCallStarted` to log the raw payload:
+
+```javascript
+console.log('[OmniAutoAnswer] callAttributes:', JSON.stringify(detail));
+```
+
+This reveals the exact key your adapter uses so you can add it to the check.
+
+### Expected Console Output
+
+When a Queue call arrives and auto-accepts:
+```
+[OmniAutoAnswer] Queue call detected, auto-accepting.
+[OmniAutoAnswer] Call accepted successfully.
+```
+
+When a DID / direct-extension call arrives (no output — this is expected):
+```
+(no logs — agent sees the Accept button as normal)
+```
 
 

--- a/force-app/main/default/flexipages/Omni_Auto_Answer_Voice_Extension.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Omni_Auto_Answer_Voice_Extension.flexipage-meta.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentName>omniAutoAnswerController</componentName>
+                <identifier>REPLACE_WITH_NAMESPACE_NAME_omniAutoAnswerController</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>main</name>
+        <type>Region</type>
+    </flexiPageRegions>
+    <masterLabel>Omni Auto Answer Voice Extension</masterLabel>
+    <template>
+        <name>opencti:defaultVoiceExtensionTemplate</name>
+    </template>
+    <type>VoiceExtension</type>
+</FlexiPage>

--- a/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.html
+++ b/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.html
@@ -1,0 +1,15 @@
+<!--
+    Copyright (c) 2021, salesforce.com, inc.
+    All rights reserved.
+    SPDX-License-Identifier: BSD-3-Clause
+    For full license text, see the LICENSE file in the repo root or
+    https://opensource.org/licenses/BSD-3-Clause
+-->
+<template>
+    <!--
+        No visible UI — this component acts as a background controller only.
+        The toolkit API element below gives access to telephony events and
+        the acceptCall() method; it renders as an empty DOM node.
+    -->
+    <lightning-service-cloud-voice-toolkit-api></lightning-service-cloud-voice-toolkit-api>
+</template>

--- a/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.js
+++ b/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { LightningElement } from 'lwc';
+
+/**
+ * OmniAutoAnswerController — Selective Auto-Answer for Service Cloud Voice
+ *
+ * WHAT IT DOES
+ * ------------
+ * Automatically accepts inbound Queue calls the moment they arrive, while
+ * leaving DID / direct-extension calls for the agent to accept manually.
+ * This mirrors physical ACD behaviour: queue calls ring through automatically,
+ * direct calls wait for the agent to pick up.
+ *
+ * WHY IT EXISTS
+ * -------------
+ * Salesforce's native "Automatically accept work requests" setting is
+ * all-or-nothing. Enabling it auto-accepts every call type, removing agent
+ * control over direct calls. Disabling it forces agents to manually click
+ * Accept on every call, adding unnecessary friction to high-volume queue work.
+ * This component provides the middle ground: auto-accept only where it helps.
+ *
+ * HOW IT WORKS
+ * ------------
+ * 1. Subscribes to the Voice Toolkit API's `callstarted` event.
+ * 2. Reads `callAttributes` from the event payload to determine routing type.
+ * 3. Queue call  → calls acceptCall() immediately; agent is connected silently.
+ * 4. DID / direct → does nothing; agent sees the standard Accept button.
+ * 5. Subscribes to `callended` to reset state cleanly for the next call.
+ *
+ * SETUP
+ * -----
+ * 1. Deploy this component and the Omni_Auto_Answer_Voice_Extension FlexiPage.
+ * 2. In Setup → Contact Centers → <your center> → SCV Settings:
+ *    - Voice Extension Flexipage: Omni Auto Answer Voice Extension
+ *    - Always Show Voice Extension: true
+ * 3. Ensure "Automatically accept work requests" is UNCHECKED in Omni-Channel
+ *    settings — the built-in setting overrides this component if enabled.
+ *
+ * ADAPTER COMPATIBILITY
+ * ---------------------
+ * Partner telephony adapters surface routing context under different key names.
+ * Three common ones are checked below. If auto-accept is not firing, uncomment
+ * the debug line in handleCallStarted to log the raw payload and identify the
+ * exact key your connector uses.
+ *
+ * TECHNICAL NOTES
+ * ---------------
+ * - Bound handler references are stored in constructor() so removeEventListener
+ *   works correctly (bind() creates a new function reference each time).
+ * - disconnectedCallback removes all listeners to prevent memory leaks.
+ * - _accepting flag prevents duplicate acceptCall() if the adapter fires
+ *   callstarted more than once per call; reset by callended for the next call.
+ */
+export default class OmniAutoAnswerController extends LightningElement {
+    _hasRendered = false;
+    _accepting = false; // guard against duplicate callstarted events per call
+
+    constructor() {
+        super();
+        // Store bound references so the same function can be passed to removeEventListener
+        this._onCallStarted = this.handleCallStarted.bind(this);
+        this._onCallEnded = this.handleCallEnded.bind(this);
+    }
+
+    renderedCallback() {
+        if (this._hasRendered) return;
+        this._hasRendered = true;
+
+        const toolkit = this.template.querySelector(
+            'lightning-service-cloud-voice-toolkit-api'
+        );
+        if (!toolkit) return;
+
+        this._toolkit = toolkit;
+        toolkit.addEventListener('callstarted', this._onCallStarted);
+        toolkit.addEventListener('callended', this._onCallEnded);
+    }
+
+    disconnectedCallback() {
+        if (this._toolkit) {
+            this._toolkit.removeEventListener('callstarted', this._onCallStarted);
+            this._toolkit.removeEventListener('callended', this._onCallEnded);
+        }
+    }
+
+    handleCallStarted(event) {
+        if (this._accepting) return; // prevent duplicate acceptCall on repeated events
+
+        const detail = event.detail || {};
+        const attrs = detail.callAttributes || {};
+
+        /*
+         * Uncomment to log the raw callAttributes payload and identify which
+         * key your telephony adapter uses if auto-accept is not firing:
+         *
+         * console.log('[OmniAutoAnswer] callAttributes:', JSON.stringify(detail));
+         */
+
+        // Key names observed across common partner telephony adapters
+        const isQueueCall =
+            attrs.routingType === 'Queue' ||
+            attrs.callRoutingType === 'Queue' ||
+            attrs.queueCall === true;
+
+        if (!isQueueCall) {
+            // Log the raw attributes so you can identify the exact key/value your
+            // adapter sends for DID / direct-extension calls and add an explicit check.
+            console.log('[OmniAutoAnswer] Non-queue call, leaving for manual accept. callAttributes:', JSON.stringify(attrs));
+            return;
+        }
+
+        this._accepting = true;
+        console.log('[OmniAutoAnswer] Queue call detected, auto-accepting.');
+
+        this._toolkit
+            .acceptCall()
+            .then(() => console.log('[OmniAutoAnswer] Call accepted successfully.'))
+            .catch((err) => {
+                console.error('[OmniAutoAnswer] acceptCall failed:', err);
+                this._accepting = false; // reset so a retry is possible
+            });
+    }
+
+    handleCallEnded() {
+        this._accepting = false; // reset for the next call
+    }
+}

--- a/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.js-meta.xml
+++ b/force-app/main/default/lwc/omniAutoAnswerController/omniAutoAnswerController.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>Omni Auto Answer Controller</masterLabel>
+    <targets>
+        <target>lightning__VoiceExtension</target>
+    </targets>
+    <capabilities>
+        <capability>lightning__ServiceCloudVoiceToolkitApi</capability>
+    </capabilities>
+</LightningComponentBundle>


### PR DESCRIPTION
## The Problem

Salesforce's native **Automatically accept work requests** setting is all-or-nothing. Enabling it auto-accepts every call type, removing agent control over direct calls. Disabling it forces agents to manually click Accept on every call — adding friction on high-volume queue work. There is no out-of-the-box way to auto-accept one type and not the other.

## What This Adds

`omniAutoAnswerController` is a background Voice Extension LWC that brings **intelligent, selective call auto-answering** to the agent console — without any Apex code, custom permissions, or third-party dependencies.

- **Queue call** → Auto-accepts immediately. The agent is connected without lifting a finger.
- **DID / direct-extension call** → Does nothing. The agent sees the standard Accept button and controls when to pick up.

## Components

| Name | Type | Description |
|---|---|---|
| `omniAutoAnswerController` | Lightning Web Component | Background Voice Extension that subscribes to `callstarted` / `callended` Toolkit API events and selectively calls `acceptCall()` for Queue-routed calls only |
| `Omni_Auto_Answer_Voice_Extension` | FlexiPage | VoiceExtension FlexiPage that wires `omniAutoAnswerController` to the Contact Center — assign this under SCV Settings → Voice Extension Flexipage |

## Key Capabilities

| Capability | Detail |
|---|---|
| Selective auto-answer | Accepts Queue calls only; leaves DID / direct calls manual |
| Adapter-agnostic | Checks all three common `callAttributes` key names used across partner telephony adapters |
| DID call visibility | Logs raw `callAttributes` on non-queue calls so the exact adapter key for DID can be identified and locked in |
| Zero UI footprint | Runs entirely in the background; no visible panel or buttons rendered |
| Memory-safe | Removes event listeners on component disconnect via `disconnectedCallback` |
| Duplicate-proof | `_accepting` flag prevents repeated `acceptCall()` if the adapter fires `callstarted` more than once; resets on `callended` |
| Debug-ready | Built-in commented hook to log raw `callAttributes` for adapter-specific key discovery |

## How DID Detection Works

The component uses a safe negative default — anything that does not positively match a Queue indicator is left for manual accept. On non-queue calls it logs the raw `callAttributes` to DevTools:

```
[OmniAutoAnswer] Non-queue call, leaving for manual accept. callAttributes: {"routingType":"Direct",...}
```

This makes it easy to identify the exact key/value your adapter sends for DID calls so an explicit check can be added once confirmed.

## Expected Console Output

**Queue call (auto-accepted):**
```
[OmniAutoAnswer] Queue call detected, auto-accepting.
[OmniAutoAnswer] Call accepted successfully.
```

**DID / direct-extension call (manual accept):**
```
[OmniAutoAnswer] Non-queue call, leaving for manual accept. callAttributes: {...}
```

## Setup

1. Deploy `omniAutoAnswerController` and `Omni_Auto_Answer_Voice_Extension` to your org.
2. In Setup → **Contact Centers** → your contact center → **SCV Settings**:
   - Set **Voice Extension Flexipage** to `Omni Auto Answer Voice Extension`
   - Set **Always Show Voice Extension** to `true`
3. Ensure **Automatically accept work requests** is **unchecked** in Omni-Channel settings — the built-in setting overrides this component if enabled.

## Test Plan

- [ ] Deploy component and FlexiPage to a Partner Telephony-enabled org
- [ ] Assign `Omni Auto Answer Voice Extension` FlexiPage in Contact Center SCV Settings
- [ ] Confirm "Automatically accept work requests" is unchecked
- [ ] Place a Queue-routed inbound call — should auto-accept; DevTools should show `[OmniAutoAnswer] Queue call detected, auto-accepting.` and `[OmniAutoAnswer] Call accepted successfully.`
- [ ] Place a DID / direct-extension inbound call — agent should see the Accept button; DevTools should show `[OmniAutoAnswer] Non-queue call, leaving for manual accept. callAttributes: {...}`
- [ ] Unmount/remount the Voice Extension panel — confirm no duplicate listeners or JS errors
- [ ] Place two back-to-back Queue calls — confirm `_accepting` resets correctly between calls